### PR TITLE
Support Minitest v6 while maintaining compatibility with v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Or install it yourself as:
 
     $ gem install minitest-fail-fast
 
-And finally, add this to your `test_helper.rb`:
+If you are using Minitest 6+, add this to your `test_helper`:
 
 ```ruby
-require "minitest/fail_fast"
+# Needed for Minitest 6
+Minitest.load :fail_fast
 ```
 
 ## Usage
@@ -31,11 +32,7 @@ You can either activate the plugin by passing `-f`, `--fail-fast`:
 
     $ TESTOPTS="--fail-fast" bundle exec rake
 
-Or by explicitly calling the following in your `test_helper.rb`:
-
-```ruby
-Minitest::FailFastReporter.fail_fast!
-```
+Or by requiring `minitest/fail_fast` in your `test_helper`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,23 @@ Or install it yourself as:
 
     $ gem install minitest-fail-fast
 
+And finally, add this to your `test_helper.rb`:
+
+```ruby
+require "minitest/fail_fast"
+```
+
 ## Usage
 
 You can either activate the plugin by passing `-f`, `--fail-fast`:
 
     $ TESTOPTS="--fail-fast" bundle exec rake
 
-Or by requiring `minitest/fail_fast` in your `test_helper`:
+Or by explicitly calling the following in your `test_helper.rb`:
+
+```ruby
+Minitest::FailFastReporter.fail_fast!
+```
 
 ## Contributing
 

--- a/lib/minitest/fail_fast.rb
+++ b/lib/minitest/fail_fast.rb
@@ -1,5 +1,5 @@
 require "minitest"
 require_relative "fail_fast_plugin"
 
-Minitest.load(:fail_fast) if Minitest.respond_to?(:load) # MT6
-
+Minitest.load_plugins if Minitest::VERSION.to_i < 6
+Minitest::FailFastReporter.fail_fast!

--- a/lib/minitest/fail_fast.rb
+++ b/lib/minitest/fail_fast.rb
@@ -1,4 +1,5 @@
 require "minitest"
+require_relative "fail_fast_plugin"
 
-Minitest.load_plugins
-Minitest::FailFastReporter.fail_fast!
+Minitest.load(:fail_fast) if Minitest.respond_to?(:load) # MT6
+

--- a/minitest-fail-fast.gemspec
+++ b/minitest-fail-fast.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "minitest", "~> 5"
+  spec.add_dependency "minitest", ">= 5.0", "< 7"
   spec.add_development_dependency "rake", "~> 13.3"
 end

--- a/minitest-fail-fast.gemspec
+++ b/minitest-fail-fast.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "minitest", "~> 5"
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.3"
 end

--- a/test/minitest/fail_fast_test.rb
+++ b/test/minitest/fail_fast_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "minitest/fail_fast"
+Minitest::FailFastReporter.fail_fast!
 
 module Minitest
   class FailFastTest < Minitest::Test

--- a/test/minitest/fail_fast_test.rb
+++ b/test/minitest/fail_fast_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require "minitest/fail_fast"
-Minitest::FailFastReporter.fail_fast!
+
+Minitest.load(:fail_fast) if Minitest::VERSION.to_i >= 6
 
 module Minitest
   class FailFastTest < Minitest::Test


### PR DESCRIPTION
The biggest change in Minitest 6 is that it no longer loads plugins automatically. Therefore, to install the `-f` / `--fail-fast` command line options into Minitest, the user must first explicitly load the plugin.

I've updated the README to explain this. I also updated the gemspec to allow for Minitest 5 and 6.

Fixes #3 