### PR TITLE
Add CI summary job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,12 @@ jobs:
         env:
           MINITEST_VERSION: ${{ matrix.minitest }}
         run: bundle exec rake
+
+  ci:
+    name: CI
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          [[ "${{ needs.test.result }}" == "success" ]] || exit 1


### PR DESCRIPTION
Adds a summary `CI` job that depends on the matrix `test` job so
branch protection can require a single stable check name instead of
individual matrix entries.